### PR TITLE
Modified validation of webhook URL to allow optional service/

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@ class reportslack (
   $webhook,
   $channel,
 ) {
-  validate_re($webhook, 'https:\/\/hooks.slack.com\/T.+\/B.+\/.+', 'The webhook URL is invalid')
+  validate_re($webhook, 'https:\/\/hooks.slack.com\/(services\/)?T.+\/B.+\/.+', 'The webhook URL is invalid')
   validate_re($channel, '#.+', 'The channel should start with a hash sign')
 
   package { 'slack-notifier':


### PR DESCRIPTION
Modified validation of webhook URL to allow optional service/ which is used by Slack's Incoming Webhooks app (https://slack.com/apps/A0F7XDUAZ-incoming-webhooks). Using Slack's Incoming Webhooks app has the advantage that it can be used for multiple purposes, and due to slack limiting the number of integrations for free accounts its a good idea to reuse these integrations where possible.
